### PR TITLE
Updated docs to clarify running taps and target in different envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Deactivate the `tap-fixerio` virtual environment by using the `deactivate` comma
 then set up the `target-csv` virtual environment according to the instructions
 [here](https://github.com/singer-io/target-csv/blob/master/README.md).
 
-Once `target-csv`, or another Singer target, is installed in its own virtual environment run them with the following command:
+Once `target-csv`, or another Singer target, is installed in its own virtual
+environment run them with the following command:
 
 ```bash
 ~/.virtualenvs/tap-fixerio/bin/tap-fixerio --config ~/singer.io/tap_fixerio_config.json | ~/.virtualenvs/target-csv/bin/target-csv

--- a/README.md
+++ b/README.md
@@ -32,18 +32,21 @@ pip install -U pip setuptools
 pip install -e '.'
 ```
 
-Set up the `target-csv` virtual environment according to the instructions
+Like all Singer taps, the output of `tap-fixerio` should be piped to a Singer target. 
+Deactivate the `tap-fixerio` virtual environment by using the `deactivate` command, 
+then set up the `target-csv` virtual environment according to the instructions
 [here](https://github.com/singer-io/target-csv/blob/master/README.md).
-These commands will install `tap-fixerio`  with pip, and then run it:
+
+Once `target-csv`, or another Singer target, is installed in its own virtual environment run them with the following command:
 
 ```bash
-~/.virtualenvs/tap-fixerio/bin/tap-fixerio --config \ ~/singer.io/tap_fixerio_config.json | target-csv
+~/.virtualenvs/tap-fixerio/bin/tap-fixerio --config ~/singer.io/tap_fixerio_config.json | ~/.virtualenvs/target-csv/bin/target-csv
 ```
 
 The data will be written to a file called `exchange_rate.csv` in your
 working directory.
 
-```
+```bash
 $ cat exchange_rate.csv
 AUD,BGN,BRL,CAD,CHF,CNY,CZK,DKK,GBP,HKD,HRK,HUF,IDR,ILS,INR,JPY,KRW,MXN,MYR,NOK,NZD,PHP,PLN,RON,RUB,SEK,SGD,THB,TRY,ZAR,EUR,USD,date
 1.3023,1.8435,3.0889,1.3109,1.0038,6.869,25.47,7.0076,0.79652,7.7614,7.0011,290.88,13317.0,3.6988,66.608,112.21,1129.4,19.694,4.4405,8.3292,1.3867,50.198,4.0632,4.2577,58.105,8.9724,1.4037,34.882,3.581,12.915,0.9426,1.0,2017-02-24T00:00:00Z


### PR DESCRIPTION
Based on @timvisher's [suggestion](https://github.com/singer-io/tap-fixerio/pull/6#pullrequestreview-189832237), I took a crack at updating README.md to clarify how to install the tap and target in separate virtualenvs and then run them.

Open to further edits if these aren't clear.