### PR TITLE
Adds support to free subscription plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Then, convert `config.sample.json` to
 
 Config Key | Required? | Default | Description
 --- | --- | --- | ---
-`base` | Yes | 'USD' | The base rate to which others will be converted
+`subscription_plan` | Yes | 'free' | Your fixer.io subscription plan
 `start_date` | Yes | Today | The starting date from which rates will be pulled in `YYYY-MM-DD` format (overridden if a state file is passed)
 `access_key` | Yes | None | Your fixer.io access key
 `symbols` | No | None | An optional list of currency symbols to fetch in the following format: ['USD', 'GBP', etc.]. If not specified fixer will return a list of all exchange rates for each day
+`base` | Yes | 'USD' | The base rate to which others will be converted (not available in free subscription plan, for which it is set to 'EUR')
 
 It's recommended to use a virtualenv:
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,6 +1,7 @@
 {
-    "base": "USD",
+    "subscription_plan": "free",
     "start_date": "<YYYY-MM-DD>",
     "access_key": "<your_access_key>",
-    "symbols": ["USD","EUR","GBP","JPY"]
+    "symbols": ["USD","EUR","GBP","JPY"],
+    "base": "USD"
 }


### PR DESCRIPTION
This PR aims to solve issue #8 to make this tap compatible with [Getting Started example](https://github.com/singer-io/getting-started/blob/master/docs/RUNNING_AND_DEVELOPING.md#example---using-singer-to-populate-google-sheets) again (referenced [here](https://github.com/singer-io/getting-started/issues/58) as well).

The enhancement adds a parameter for `subscription_plan`, based on which the request is customised (uses HTTP and omits `base` parameter).

If this PR is approved, I am able to suggest updates in the Getting Started example's documentation to solve that major issue with new users' first experience using Singer.

I tested the changes with the example use case (Google Sheets Target) and it works fine.