### PR TITLE
fix: Stop using `singer.utils.parse_args` as it adds more CLI options than the tap supports

### DIFF
--- a/tap_fixerio.py
+++ b/tap_fixerio.py
@@ -92,18 +92,18 @@ def main():
     parser.add_argument(
         '-s', '--state', help='State file', required=False)
 
-    #args = parser.parse_args()
-    args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
-
+    args = parser.parse_args()
     if args.config:
-        config = args.config
+        config = singer.utils.load_json(args.config)
     else:
         config = {}
 
     if args.state:
-        state = args.state
+        state = singer.utils.load_json(args.state)
     else:
         state = {}
+
+    singer.utils.check_config(config, REQUIRED_CONFIG_KEYS)
 
     start_date = state.get('start_date',
                            config.get('start_date', datetime.utcnow().strftime(DATE_FORMAT)))


### PR DESCRIPTION
# Description of change

Stop using `singer.utils.parse_args`, as it adds more CLI options than the tap supports. The `--discover`, `--catalog` and `--properties` options are not supported, so there's no reason to advertise them.

# Manual QA steps

```console
$ tap-fixerio --help
usage: tap-fixerio [-h] [-c CONFIG] [-s STATE]

optional arguments:
  -h, --help            show this help message and exit
  -c CONFIG, --config CONFIG
                        Config file
  -s STATE, --state STATE
                        State file
```

```console
$ tap-fixerio
Traceback (most recent call last):
  File "/tap-fixerio/.venv/bin/tap-fixerio", line 10, in <module>
    sys.exit(main())
  File "/tap-fixerio/tap_fixerio.py", line 106, in main
    singer.utils.check_config(config, REQUIRED_CONFIG_KEYS)
  File "/tap-fixerio/.venv/lib/python3.9/site-packages/singer/utils.py", line 190, in check_config
    raise Exception("Config is missing required keys: {}".format(missing_keys))
Exception: Config is missing required keys: ['access_key']
```

# Risks

None that I can think of.
 
# Rollback steps

Revert this branch.

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
